### PR TITLE
Dict typing fixes

### DIFF
--- a/tuplex/codegen/include/SymbolTable.h
+++ b/tuplex/codegen/include/SymbolTable.h
@@ -185,9 +185,22 @@ namespace tuplex {
          * @param typer a dynamic typing function
          * @param sym_type what kind of symbol it is (function? variable?), needed because typer works for both.
          */
-        void addBuiltinTypeAttribute(const python::Type& builtinType, const std::string& name,
+        void addBuiltinTypeAttribute(const python::Type& builtinType,
+                                     const std::string& name,
                                      std::function<python::Type(const python::Type&)> typer,
                                      const SymbolType& sym_type);
+
+        /*!
+         * add an attribute to a builtin type, e.g. dict.keys()
+         * @param builtinType to which type to add the function
+         * @param name name of the attribute
+         * @param typer a dynamic typing function
+         * @param sym_type what kind of symbol it is (function? variable?), needed because typer works for both.
+         */
+        void addBuiltinTypeAttribute(const python::Type& builtinType,
+                                     const std::string& name,
+                                     std::function<python::Type(const python::Type&, const python::Type&)> attributeTyper,
+                                     const SymbolType& sym_type=SymbolType::FUNCTION);
 
         /*!
          * checks whether a symbol can be looked up or not

--- a/tuplex/codegen/src/SymbolTable.cc
+++ b/tuplex/codegen/src/SymbolTable.cc
@@ -412,6 +412,8 @@ namespace tuplex {
         {
             addBuiltinTypeAttribute(python::Type::GENERICDICT, "keys", [](const python::Type& parameterType) {
 
+                //  @TODO: @rhea once you changed the signature of the Lambda here, you should be abel to type correctly.
+                // I can give it a try to refactor everything better than. 
                 std::cout<<"need to get concrete dict type here!"<<std::endl;
 
                 return python::Type::UNKNOWN;
@@ -811,6 +813,8 @@ namespace tuplex {
                     // else, return single type
                     return attr_sym->type();
                 python::Type funcType = python::Type::UNKNOWN;
+
+                //  @TODO: @rhea -> change function here to include objectType as well and make typer a two parameter function
                 attr_sym->findFunctionTypeBasedOnParameterType(parameterType, funcType); // ignore ret value.
                 return funcType;
             }

--- a/tuplex/codegen/src/SymbolTable.cc
+++ b/tuplex/codegen/src/SymbolTable.cc
@@ -413,7 +413,7 @@ namespace tuplex {
             addBuiltinTypeAttribute(python::Type::GENERICDICT, "keys", [](const python::Type& parameterType) {
 
                 //  @TODO: @rhea once you changed the signature of the Lambda here, you should be abel to type correctly.
-                // I can give it a try to refactor everything better than. 
+                // I can give it a try to refactor everything better than.
                 std::cout<<"need to get concrete dict type here!"<<std::endl;
 
                 return python::Type::UNKNOWN;

--- a/tuplex/codegen/src/TypeAnnotatorVisitor.cc
+++ b/tuplex/codegen/src/TypeAnnotatorVisitor.cc
@@ -1763,6 +1763,26 @@ namespace tuplex {
             } else if(exprType.isIteratorType()) {
                 _nameTable[id->_name] = exprType.yieldType();
                 id->setInferredType(exprType.yieldType());
+            } else if(exprType.isDictValuesType()) {
+                auto dict_type = exprType.elementType();
+                auto yield_type = dict_type.valueType();
+                if(yield_type == python::Type::PYOBJECT || yield_type == python::Type::UNKNOWN) {
+                    // might require unrolling & speculation on view length!
+                    addCompileError(CompileError::TYPE_ERROR_UNSUPPORTED_LOOP_TESTLIST_TYPE);
+                    return;
+                }
+                _nameTable[id->_name] = yield_type;
+                id->setInferredType(yield_type);
+            } else if(exprType.isDictKeysType()) {
+                auto dict_type = exprType.elementType();
+                auto yield_type = dict_type.keyType();
+                if(yield_type == python::Type::PYOBJECT || yield_type == python::Type::UNKNOWN) {
+                    // might require unrolling & speculation on view length!
+                    addCompileError(CompileError::TYPE_ERROR_UNSUPPORTED_LOOP_TESTLIST_TYPE);
+                    return;
+                }
+                _nameTable[id->_name] = yield_type;
+                id->setInferredType(yield_type);
             } else {
                 addCompileError(CompileError::TYPE_ERROR_UNSUPPORTED_LOOP_TESTLIST_TYPE);
             }

--- a/tuplex/test/core/DictionaryTyping.cc
+++ b/tuplex/test/core/DictionaryTyping.cc
@@ -637,11 +637,7 @@ TEST(DictionaryTyping, KeyView) {
     using namespace std;
 
     // could also use list((10, 20, 30)) e.g., or tuple(list(...)) -> needs speculation.
-
     // test count UDF
-//    auto count_c = "def count_keys(x):\n"
-//                   "    d = {'A':10, 'B': 10, x: 20}\n"
-//                   "    return list(d.keys())";
     auto count_c = "def count_keys(x):\n"
                    "    d = {'A':10, 'B': 10, x: 20}\n"
                    "    return d.keys()";
@@ -663,6 +659,33 @@ TEST(DictionaryTyping, KeyView) {
     graph.saveAsPDF("dict_count_keys.pdf");
 
     cout<<"return type of function is: "<<ast.getReturnType().desc()<<endl;
+    auto underlying_dict = python::Type::makeDictionaryType(python::Type::STRING, python::Type::I64);
+    ASSERT_EQ(ast.getReturnType(), python::Type::makeDictKeysViewType(underlying_dict));
+}
 
-    ASSERT_EQ(ast.getReturnType(), python::Type::makeDictionaryType(python::Type::STRING, python::Type::I64));
+TEST(DictionaryTyping, KeyViewWithListConversion) {
+    // expected to fail; need to add support for dict_keys
+    using namespace tuplex;
+    using namespace std;
+
+    // could also use list((10, 20, 30)) e.g., or tuple(list(...)) -> needs speculation.
+
+    // test count UDF
+    auto count_c = "def count_keys(x):\n"
+                   "    d = {'A':10, 'B': 10, x: 20}\n"
+                   "    return list(d.keys())";
+
+    // parse code to AST
+    auto ast = tuplex::codegen::AnnotatedAST();
+    ast.parseString(count_c);
+
+    // make typing
+    python::Type inputType = python::Type::STRING;
+
+    // create symbol table
+    ast.addTypeHint("x", inputType);
+    ast.defineTypes(codegen::DEFAULT_COMPILE_POLICY);
+
+    cout<<"return type of function is: "<<ast.getReturnType().desc()<<endl;
+    ASSERT_EQ(ast.getReturnType(), python::Type::makeListType(python::Type::STRING));
 }

--- a/tuplex/test/core/DictionaryTyping.cc
+++ b/tuplex/test/core/DictionaryTyping.cc
@@ -542,7 +542,7 @@ TEST(DictionaryTyping, DictionaryInputControlFlow) {
     // print type annotated ast
     GraphVizGraph graph;
     graph.createFromAST(ast.getFunctionAST(), true);
-    graph.saveAsPDF("/home/rgoyal6/tuplex/tuplex/build/dictionary_asts/dict_input_control_flow.pdf");
+    graph.saveAsPDF("dict_input_control_flow.pdf");
 
     cout<<"return type of function is: "<<ast.getReturnType().desc()<<endl;
 
@@ -586,7 +586,7 @@ TEST(DictionaryTyping, Everything) {
     // print type annotated ast
     GraphVizGraph graph;
     graph.createFromAST(ast.getFunctionAST(), true);
-    graph.saveAsPDF("/home/rgoyal6/tuplex/tuplex/build/dictionary_asts/everything.pdf");
+    graph.saveAsPDF("dict_everything.pdf");
 
     cout<<"return type of function is: "<<ast.getReturnType().desc()<<endl;
 

--- a/tuplex/utils/include/TypeSystem.h
+++ b/tuplex/utils/include/TypeSystem.h
@@ -224,8 +224,8 @@ namespace python {
 
         static Type makeListType(const python::Type &elementType);
 
-        static Type makeDictKeysType(const python::Type& keyType);
-        static Type makeDictValuesType(const python::Type& valType);
+        static Type makeDictKeysViewType(const python::Type& dictType);
+        static Type makeDictValuesViewType(const python::Type& dictType);
 
         /*!
          * create iterator type from yieldType.
@@ -359,8 +359,8 @@ namespace python {
         // right now, no tuples or other weird types...
         Type createOrGetFunctionType(const Type& param, const Type& ret=Type::EMPTYTUPLE);
         Type createOrGetDictionaryType(const Type& key, const Type& val);
-        Type createOrGetDictKeysType(const Type& key);
-        Type createOrGetDictValuesType(const Type& val);
+        Type createOrGetDictKeysViewType(const Type& key);
+        Type createOrGetDictValuesViewType(const Type& val);
         Type createOrGetListType(const Type& val);
         Type createOrGetTupleType(const std::initializer_list<Type> args);
         Type createOrGetTupleType(const TTuple<Type>& args);

--- a/tuplex/utils/src/TypeSystem.cc
+++ b/tuplex/utils/src/TypeSystem.cc
@@ -149,18 +149,18 @@ namespace python {
         return registerOrGetType(name, AbstractType::DICTIONARY, {key, val});
     }
 
-    Type TypeFactory::createOrGetDictKeysType(const Type& key) {
+    Type TypeFactory::createOrGetDictKeysViewType(const Type& key) {
         std::string name;
-        name += "[";
+        name += "DictKeysView[";
         name += TypeFactory::instance().getDesc(key._hash);
         name += "]";
 
         return registerOrGetType(name, AbstractType::DICT_KEYS, {key});
     }
 
-    Type TypeFactory::createOrGetDictValuesType(const Type& val) {
+    Type TypeFactory::createOrGetDictValuesViewType(const Type& val) {
         std::string name;
-        name += "[";
+        name += "DictValuesView[";
         name += TypeFactory::instance().getDesc(val._hash);
         name += "]";
 
@@ -583,12 +583,12 @@ namespace python {
         return python::TypeFactory::instance().createOrGetDictionaryType(keyType, valType);
     }
 
-    Type Type::makeDictKeysType(const python::Type& keyType) {
-        return python::TypeFactory::instance().createOrGetDictKeysType(keyType);
+    Type Type::makeDictKeysViewType(const python::Type& keyType) {
+        return python::TypeFactory::instance().createOrGetDictKeysViewType(keyType);
     }
 
-    Type Type::makeDictValuesType(const python::Type& valType) {
-        return python::TypeFactory::instance().createOrGetDictValuesType(valType);
+    Type Type::makeDictValuesViewType(const python::Type& valType) {
+        return python::TypeFactory::instance().createOrGetDictValuesViewType(valType);
     }
 
     Type Type::makeListType(const python::Type &elementType){


### PR DESCRIPTION
Adds the following:

- dict_views for key/values -> they take dictionary type as basetype. Required because of structdicts in json branch
- add `list` builtin function to typing
- attributes may now be typed using an `attributeTyper` function that is based on both caller type and parameter type (required for the dict_views)
- removed user-specific paths...